### PR TITLE
Fix for /hgps output conflict with VoxelMap

### DIFF
--- a/src/nu/nerd/easyrider/commands/HorseGPSExecutor.java
+++ b/src/nu/nerd/easyrider/commands/HorseGPSExecutor.java
@@ -161,7 +161,7 @@ public class HorseGPSExecutor extends ExecutorBase {
                 : Util.limitString(savedHorse.getUuid().toString(), 20);
             player.sendMessage(ChatColor.GOLD + id + ChatColor.GRAY + " is at:");
             StringBuilder message = new StringBuilder();
-            message.append(ChatColor.WHITE).append('(');
+            message.append(ChatColor.WHITE).append('[');
             message.append(ChatColor.GOLD).append("Name: ").append(ChatColor.YELLOW).append("HGPS");
             message.append(ChatColor.WHITE).append(", ");
             message.append(ChatColor.GOLD).append("X: ").append(ChatColor.YELLOW).append(horseLoc.getBlockX());
@@ -170,8 +170,8 @@ public class HorseGPSExecutor extends ExecutorBase {
             message.append(ChatColor.WHITE).append(", ");
             message.append(ChatColor.GOLD).append("Z: ").append(ChatColor.YELLOW).append(horseLoc.getBlockZ());
             message.append(ChatColor.WHITE).append(", ");
-            message.append(ChatColor.GRAY).append("dim: ").append(ChatColor.GRAY).append(horseLoc.getWorld().getEnvironment().getId());
-            message.append(ChatColor.WHITE).append(')');
+            message.append(ChatColor.GRAY).append("d: ").append(ChatColor.GRAY).append(horseLoc.getWorld().getEnvironment().getId());
+            message.append(ChatColor.WHITE).append(']');
 
             if (horseLoc.getWorld().equals(playerLoc.getWorld())) {
                 int distance = (int) playerLoc.distance(horseLoc);

--- a/src/nu/nerd/easyrider/commands/HorseGPSExecutor.java
+++ b/src/nu/nerd/easyrider/commands/HorseGPSExecutor.java
@@ -161,7 +161,7 @@ public class HorseGPSExecutor extends ExecutorBase {
                 : Util.limitString(savedHorse.getUuid().toString(), 20);
             player.sendMessage(ChatColor.GOLD + id + ChatColor.GRAY + " is at:");
             StringBuilder message = new StringBuilder();
-            message.append(ChatColor.WHITE).append('[');
+            message.append(ChatColor.WHITE).append('(');
             message.append(ChatColor.GOLD).append("Name: ").append(ChatColor.YELLOW).append("HGPS");
             message.append(ChatColor.WHITE).append(", ");
             message.append(ChatColor.GOLD).append("X: ").append(ChatColor.YELLOW).append(horseLoc.getBlockX());
@@ -171,7 +171,7 @@ public class HorseGPSExecutor extends ExecutorBase {
             message.append(ChatColor.GOLD).append("Z: ").append(ChatColor.YELLOW).append(horseLoc.getBlockZ());
             message.append(ChatColor.WHITE).append(", ");
             message.append(ChatColor.GRAY).append("dim: ").append(ChatColor.GRAY).append(horseLoc.getWorld().getEnvironment().getId());
-            message.append(ChatColor.WHITE).append(']');
+            message.append(ChatColor.WHITE).append(')');
 
             if (horseLoc.getWorld().equals(playerLoc.getWorld())) {
                 int distance = (int) playerLoc.distance(horseLoc);


### PR DESCRIPTION
Voxelmap is currently eating the /hgps location data output because of how it's interpreting the brackets wrapped around the output. Simple fix is to replace the brackets with paranthesis. Tested with identical client setup including VoxelMap and Fabric on both p.nerd.nu and locally to confirm the fix.

This is a minor fix that anyone could make, so I won't feel bad if this PR is rejected.

Here's a screenshot of the updated output with parens instead of brackets:

https://imgur.com/a/S17PLcK