### PR TITLE
Allow horse identifier or name in /horse-access

### DIFF
--- a/src/nu/nerd/easyrider/Util.java
+++ b/src/nu/nerd/easyrider/Util.java
@@ -1,13 +1,13 @@
 package nu.nerd.easyrider;
 
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
-import org.bukkit.Bukkit;
-import org.bukkit.Chunk;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.World;
+import nu.nerd.easyrider.db.SavedHorse;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Waterlogged;
@@ -222,6 +222,47 @@ public class Util {
             }
         }
         return null;
+    }
+
+    // ------------------------------------------------------------------------
+    /**
+     * Return a list of SavedHorses owned by the specified player that match the
+     * specified identifier.
+     *
+     * @param owner      the owning player.
+     * @param identifier identifies the horse, either with the horse's
+     *                   /horse-owned index, an AbstractHorse Entity UUID or the
+     *                   name of the horse.
+     * @return a non-null list of SavedHorses; this will be empty if no match is
+     *         found.
+     */
+    public static List<SavedHorse> findHorses(OfflinePlayer owner, String identifier) {
+        final String lowerIdent = identifier.toLowerCase();
+
+        List<SavedHorse> horses = EasyRider.DB.getOwnedHorses(owner);
+        try {
+            int index = Integer.parseInt(lowerIdent);
+            if (index > 0 && index <= horses.size()) {
+                return Collections.singletonList(horses.get(index - 1));
+            }
+        } catch (NumberFormatException ignored) {
+        }
+
+        List<SavedHorse> found = horses.stream()
+                .filter(h -> h.getDisplayName().toLowerCase().startsWith(lowerIdent))
+                .collect(Collectors.toList());
+        if (!found.isEmpty()) {
+            return found;
+        }
+
+        found = horses.stream()
+                .filter(h -> h.getUuid().toString().toLowerCase().startsWith(lowerIdent))
+                .collect(Collectors.toList());
+        if (!found.isEmpty()) {
+            return found;
+        }
+
+        return new LinkedList<SavedHorse>();
     }
 
     // ------------------------------------------------------------------------

--- a/src/nu/nerd/easyrider/commands/HorseAccessExecutor.java
+++ b/src/nu/nerd/easyrider/commands/HorseAccessExecutor.java
@@ -6,8 +6,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.UUID;
 
+import nu.nerd.easyrider.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
@@ -58,9 +58,7 @@ public class HorseAccessExecutor extends ExecutorBase {
         } else {
             // Treat the first arg as the partial UUID of the affected horse.
             List<SavedHorse> horses = EasyRider.DB.getOwnedHorses(sendingPlayer);
-            List<SavedHorse> found = horses.stream()
-            .filter(h -> h.getUuid().toString().toLowerCase().startsWith(args[0]))
-            .collect(Collectors.toList());
+            List<SavedHorse> found = Util.findHorses(sendingPlayer, args[0]);
             if (found.size() == 0) {
                 sender.sendMessage(ChatColor.RED + "The partial UUID " + args[0] + " does not match any animals that you own.");
             } else if (found.size() > 1) {

--- a/src/nu/nerd/easyrider/commands/HorseGPSExecutor.java
+++ b/src/nu/nerd/easyrider/commands/HorseGPSExecutor.java
@@ -1,12 +1,9 @@
 package nu.nerd.easyrider.commands;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -58,23 +55,23 @@ public class HorseGPSExecutor extends ExecutorBase {
         String identifier;
         if (args.length == 1) {
             identifier = args[0];
-            horses = findHorses(sendingPlayer, identifier);
+            horses = Util.findHorses(sendingPlayer, identifier);
         } else {
             identifier = String.join(" ", args);
             if (sender.hasPermission("easyrider.gps-player")) {
-                horses = findHorses(sendingPlayer, identifier);
+                horses = Util.findHorses(sendingPlayer, identifier);
                 if (horses.size() == 0) {
                     @SuppressWarnings("deprecation")
                     OfflinePlayer owner = Bukkit.getOfflinePlayer(args[0]);
                     if (owner != null) {
                         identifier = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
-                        horses = findHorses(owner, identifier);
+                        horses = Util.findHorses(owner, identifier);
                     }
                 }
             } else {
                 // If a player doesn't have permission to locate others' horses,
                 // all args are the horse name.
-                horses = findHorses(sendingPlayer, identifier);
+                horses = Util.findHorses(sendingPlayer, identifier);
             }
         }
 
@@ -87,47 +84,6 @@ public class HorseGPSExecutor extends ExecutorBase {
         }
         return true;
     } // onCommand
-
-    // ------------------------------------------------------------------------
-    /**
-     * Return a list of SavedHorses owned by the specified player that match the
-     * specified identifier.
-     *
-     * @param owner      the owning player.
-     * @param identifier identifies the horse, either with the horse's
-     *                   /horse-owned index, an AbstractHorse Entity UUID or the
-     *                   name of the horse.
-     * @return a non-null list of SavedHorses; this will be empty if no match is
-     *         found.
-     */
-    protected List<SavedHorse> findHorses(OfflinePlayer owner, String identifier) {
-        final String lowerIdent = identifier.toLowerCase();
-
-        ArrayList<SavedHorse> horses = EasyRider.DB.getOwnedHorses(owner);
-        try {
-            int index = Integer.parseInt(lowerIdent);
-            if (index > 0 && index <= horses.size()) {
-                return Arrays.asList(horses.get(index - 1));
-            }
-        } catch (NumberFormatException ex) {
-        }
-
-        List<SavedHorse> found = horses.stream()
-            .filter(h -> h.getDisplayName().toLowerCase().startsWith(lowerIdent))
-            .collect(Collectors.toList());
-        if (found.size() > 0) {
-            return found;
-        }
-
-        found = horses.stream()
-            .filter(h -> h.getUuid().toString().toLowerCase().startsWith(lowerIdent))
-            .collect(Collectors.toList());
-        if (found.size() > 0) {
-            return found;
-        }
-
-        return new LinkedList<SavedHorse>();
-    } // findHorses
 
     // ------------------------------------------------------------------------
     /**


### PR DESCRIPTION
A small quality of life improvement to make it easier to set steed permissions. The need to use a UUID has been a recurring problem when we use camels, since passengers need to be added to the access list.

Move findHorses() to utils and use it in HorseAccessExecutor. Allows specifying horse index or name instead of just the UUID.